### PR TITLE
Use Results.Json()

### DIFF
--- a/src/WeatherApi/Program.cs
+++ b/src/WeatherApi/Program.cs
@@ -47,7 +47,7 @@ app.MapGet("/forecast", async (
         return Results.NotFound();
     }
 
-    return Results.Ok(forecast);
+    return Results.Json(forecast, AppJsonSerializerContext.Default.WeatherForecast);
 });
 
 app.Run();


### PR DESCRIPTION
Use `Results.Json()` instead of `Results.Ok()` and pass through the `JsonTypeInfo` explicitly.
